### PR TITLE
ResponseWriter, HTTP.Request & ListenAndServe HandleFunc Golang Web Usage

### DIFF
--- a/interlude.go
+++ b/interlude.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+//Responswriter value assembles the HTTP server's response; by writing to it , we send data to the HTTP client
+//http.Request represents is the data structure that represents the clients HTTP request
+func handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "Hi, I love this shit %s!", r.URL.Path[1:]) //URL.Path is the path component of the URL request
+}
+
+//Main function calls the http.handleFunc, ehich tells the http package to handle all the requests to the web root with handler
+//it then calls https.listenAndServe, specifying tha it should listen on port 8080
+func main() {
+	http.HandleFunc("/", handler) //web root with handler
+	log.Fatal(http.ListenAndServe(":8080", nil))
+	//ListenAndServe always returns an error but wrapping it using the log.Fatal logs that error
+}


### PR DESCRIPTION
>>The main function begins with a call to http.HandleFunc, which tells the http package to handle
all requests to the web root ("/") with handler.
>>It then calls http.ListenAndServe, specifying that it should listen on port 8080 on any interface
(":8080"). (Don't worry about its second parameter, nil, for now.) This function will block until the
program is terminated.
>>ListenAndServe always returns an error, since it only returns when an unexpected error occurs. In
order to log that error we wrap the function call with log.Fatal.
>>The function handler is of the type http.HandlerFunc. It takes an http.ResponseWriter and
an http.Request as its arguments.
>>An http.ResponseWriter value assembles the HTTP server's response; by writing to it, we send
data to the HTTP client.
>>An http.Request is a data structure that represents the client HTTP request. r.URL.Path is the
path component of the request URL. The trailing [1:] means "create a sub-slice of Path from the
1st character to the end." This drops the leading "/" from the path name.